### PR TITLE
Add clickoff functionality to start menu

### DIFF
--- a/public/anura.css
+++ b/public/anura.css
@@ -147,6 +147,23 @@ nav li {
     transition: all .1s ease-in;
 }
 
+.clickoffChecker {
+    display: none;
+}
+
+.clickoffChecker.active {
+    position: absolute;
+    width: 100%;
+    /* TODO: make this not be a magic number later with css variables */
+    height: calc(100% - 49px);
+    z-index: 9998;
+    opacity: 0;
+    top: 0;
+    left: 0;
+    bottom: 49px;
+    display: block;
+}
+
 .launcher .topSearchBar {
     display: flex;
     flex-direction: row;

--- a/src/Anura.ts
+++ b/src/Anura.ts
@@ -310,6 +310,7 @@ document.addEventListener("anura-login-completed", async () => {
 
     document.body.appendChild(contextMenu.element);
     document.body.appendChild(launcher.element);
+    document.body.appendChild(launcher.clickoffChecker);
     document.body.appendChild(taskbar.element);
 
     (window as any).taskbar = taskbar;
@@ -326,6 +327,11 @@ document.addEventListener("anura-login-completed", async () => {
     document.addEventListener("click", (e) => {
         if (e.button != 0) return;
         (document.querySelector(".custom-menu")! as HTMLElement).style.setProperty("display", "none");
+    });
+    
+    // This feels wrong but it works and makes TSC happy
+    launcher.clickoffChecker?.addEventListener('click', () => {
+        launcher.toggleVisible();
     });
 
 });

--- a/src/Launcher.tsx
+++ b/src/Launcher.tsx
@@ -14,6 +14,10 @@ class Launcher {
     </div>
   )
 
+  clickoffChecker = (
+    <div id="clickoffChecker" class="clickoffChecker"></div>
+  )
+
   constructor() {
 
   }
@@ -21,6 +25,7 @@ class Launcher {
 
   toggleVisible() {
     this.element.classList.toggle("active")
+    this.clickoffChecker.classList.toggle("active");
   }
 
   addShortcut(name: string, svg: string, onclick: () => void) {


### PR DESCRIPTION
Pretty much the title, just accomplished by adding a second element below the start menu and checking if it gets clicked. Also we should work on making the menu close when any apps launch, like most (if not all) OSes do.