### PR TITLE
Change the way taskinfo handles being clicked

### DIFF
--- a/src/Taskbar.css
+++ b/src/Taskbar.css
@@ -41,7 +41,6 @@
 #taskinfo-container {
     position: absolute;
     height: 70%;
-    cursor: pointer;
 
     /* border: 2px solid rgba(22, 22, 22, 0.6); */
 
@@ -64,4 +63,5 @@
 
 #taskinfo-container > * {
     color: whitesmoke;
+    cursor: pointer;
 }

--- a/src/Taskbar.tsx
+++ b/src/Taskbar.tsx
@@ -75,8 +75,6 @@ class Taskbar {
                     </span>
 
                     <span class="material-symbols-outlined">
-                        // This will eventually have a small popup with the
-                        battery percentage discharging time.
                         {React.use(this.state.bat_icon)}
                     </span>
 
@@ -215,6 +213,17 @@ class Taskbar {
                     this.state.bat_icon = "battery_charging_full";
                     return;
                 }
+                // I have almost no clue if this will work but im praying.
+                battery.onchargingchange = () => {
+                    if (battery.charging) {
+                        this.state.bat_icon = "battery_charging_full";
+                        return;
+                    } else {
+                        const bat_bars = Math.round(battery.level * 7) - 1;
+                        this.state.bat_icon = `battery_${bat_bars}_bar`;
+                        return;
+                    }
+                };
                 const bat_bars = Math.round(battery.level * 7) - 1;
                 this.state.bat_icon = `battery_${bat_bars}_bar`;
             });

--- a/src/Taskbar.tsx
+++ b/src/Taskbar.tsx
@@ -62,16 +62,21 @@ class Taskbar {
                     do={this.shortcut.bind(this)}
                 ></ul>
             </nav>
-            <div
-                id="taskinfo-container"
-                on:click={() => {
-                    anura.apps["anura.settings"].open();
-                }}
-            >
+            <div id="taskinfo-container">
                 <div class="flex flexcenter">
-                    <span class="material-symbols-outlined">settings</span>
+                    <span
+                        id="settings-icn"
+                        on:click={() => {
+                            anura.apps["anura.settings"].open();
+                        }}
+                        class="material-symbols-outlined"
+                    >
+                        settings
+                    </span>
 
                     <span class="material-symbols-outlined">
+                        // This will eventually have a small popup with the
+                        battery percentage discharging time.
                         {React.use(this.state.bat_icon)}
                     </span>
 
@@ -201,6 +206,15 @@ class Taskbar {
         if (navigator.getBattery) {
             // @ts-ignore
             navigator.getBattery().then((battery) => {
+                // Gonna comment this out for now to see if you guys actually want this as a feature.
+                // if (battery.dischargingTime == Infinity) {
+                //     this.state.bat_icon = "";
+                //     return;
+                // }
+                if (battery.charging) {
+                    this.state.bat_icon = "battery_charging_full";
+                    return;
+                }
                 const bat_bars = Math.round(battery.level * 7) - 1;
                 this.state.bat_icon = `battery_${bat_bars}_bar`;
             });


### PR DESCRIPTION
taskinfo-container now only opens the settings when the actual settings icon is clicked, this could potentially lead the way to either custom taskbar icons for apps (always running apps :exploding_head:) or just to make things look neater :)