### PR TITLE
Fix launcher text alignment

### DIFF
--- a/src/Launcher.css
+++ b/src/Launcher.css
@@ -31,3 +31,7 @@ body.blur-disable #launcher {
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
 }
+
+.app-shortcut-name {
+    text-align: center;
+}


### PR DESCRIPTION
Fixes long app titles aligning text to left

![Screenshot_20240413_142958](https://github.com/MercuryWorkshop/anuraOS/assets/87151697/15b0a455-1581-430d-851d-a8e9d7ffd468)


![Screenshot_20240413_142951](https://github.com/MercuryWorkshop/anuraOS/assets/87151697/a4e71632-197e-4e4e-8351-c0bb940f220b)
