### PR TITLE
Make codespace-basic-setup.sh fully automatic

### DIFF
--- a/codespace-basic-setup.sh
+++ b/codespace-basic-setup.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 
 #fix the uuidgen command not found error
 sudo apt update
-sudo apt upgrade
+sudo apt upgrade -y
 sudo apt install -y uuid-runtime gcc-multilib
 
 #install


### PR DESCRIPTION
Currently, you need to still confirm the sudo apt upgrade. All I did is add -y to this command, making the script fully automatic.