### PR TITLE
Prevent Meta key from opening Launcher on Macs

### DIFF
--- a/src/Boot.tsx
+++ b/src/Boot.tsx
@@ -629,6 +629,7 @@ document.addEventListener("anura-login-completed", async () => {
 			alttab.onComboPress();
 		}
 		if (
+			!navigator.platform.toUpperCase().includes("MAC") &&
 			e.key.toLowerCase() === "meta" &&
 			anura.settings.get("launcher-keybind")
 		) {


### PR DESCRIPTION
The meta key (known as "Command" on Macs) is used for keyboard shortcuts instead of control, so the launcher shortcut should be disabled when using a Mac. `toUpperCase()` is used due to spelling differences between different versions of macOS (i.e, MacOS 10.11 vs macOS 10.12).

> [!NOTE]
I am unable to test these changes. Merge at your own discretion, test beforehand.